### PR TITLE
:recycle: 必要な言語実装のみプロビジョニングする

### DIFF
--- a/isucon7-qualifier/image.yml
+++ b/isucon7-qualifier/image.yml
@@ -5,9 +5,9 @@
     - mysql
     - nginx
     - webapp-go
-    - webapp-node
+#    - webapp-node
     - webapp-perl
-    - webapp-php
-    - webapp-ruby
-    - webapp-python
+#    - webapp-php
+#    - webapp-ruby
+#    - webapp-python
     - image

--- a/isucon7-qualifier/standalone.yml
+++ b/isucon7-qualifier/standalone.yml
@@ -6,9 +6,9 @@
     - mysql
     - nginx
     - webapp-go
-    - webapp-node
+#    - webapp-node
     - webapp-perl
-    - webapp-php
-    - webapp-ruby
-    - webapp-python
+#    - webapp-php
+#    - webapp-ruby
+#    - webapp-python
     - image


### PR DESCRIPTION
## Description 

掲題の通りで、`go` と `perl` のみを指定した。